### PR TITLE
Do not import bsky-utils module by default

### DIFF
--- a/src/mkd/__init__.py
+++ b/src/mkd/__init__.py
@@ -1,3 +1,2 @@
 from .main import *
-from .bsky_utils import *
 


### PR DESCRIPTION
This change prevents us from creating bsky client sessions every time we import `mkd`, which was wasteful. closes https://github.com/mikedecr/site-hugo/issues/3